### PR TITLE
`fix: move client-only mixins to client section to prevent dedicated …

### DIFF
--- a/src/main/resources/createidlx.mixins.json
+++ b/src/main/resources/createidlx.mixins.json
@@ -6,19 +6,19 @@
   "mixins": [
     "create.clipboard.ClipboardValueSettingsHandlerMixin",
     "create.displayLink.DisplayLinkBlockEntityMixin",
-    "create.displayLink.DisplayLinkScreenMixin",
     "create.displayLink.source.CurrentFloorDisplaySourceMixin",
     "create.displayLink.source.SingleLineDisplaySourceMixin",
     "create.displayLink.source.TrainStatusDisplaySourceMixin",
     "create.elevator.ElevatorColumnMixin",
     "create.elevator.ElevatorContactBlockEntityMixin",
     "create.elevator.ElevatorContraptionMixin",
-    "create.gui.ModularGuiLineBuilderMixin",
     "create.piston.MechanicalPistonBlockEntityAccessor"
   ],
   "client": [
     "create.gui.AbstractSimiScreenMixin",
     "create.gui.AbstractSimiWidgetMixin",
+    "create.displayLink.DisplayLinkScreenMixin",
+    "create.gui.ModularGuiLineBuilderMixin",
     "ponder.PonderUIAccessor"
   ],
   "server": []


### PR DESCRIPTION
## Problem
DisplayLinkScreenMixin and ModularGuiLineBuilderMixin are listed under the
common "mixins" section in createidlx.mixins.json, causing them to be loaded
on dedicated servers. Both target client-only GUI classes (DisplayLinkScreen
and ModularGuiLineBuilder) that don't exist in a server environment, resulting
in a crash on startup.

Reported in [#14](https://github.com/VladisCrafter/Create-IDLX/issues/14).

Fix
Moved both mixins to the "client" section where they belong. No logic changes.

Testing
• [ ] Client loads and functions normally
• [ ] Dedicated server starts without crashing

This fix was found by AI, fixed with AI, and pr written by AI.
I did not have time to test it yet